### PR TITLE
correção da abreviação

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Quando um livro ou curso de qualidade for recomendável a leitura, mas não enca
 ele deverá ser adicionado nas listas de [cursos extras](https://github.com/Universidade-Livre/ciencia-da-computacao/blob/main/extras/courses.md) e [livros extras](#) respectivamente.
 
 **Organização**. O Currículo é organizado da seguinte forma:
-- **Introdução a Computação**: Contêm os conteúdos de introdução, é onde você pode começar e ver se quer fazer CS.
+- **Introdução a Computação**: Contêm os conteúdos de introdução, é onde você pode começar e ver se quer fazer CC.
 - **Aprofundamento de Conceitos Introdutórios**: Contêm os conteúdos que começam a aprofundar os conceitos introdutórios.
 - **Desenvolvimento Teórico**: Contêm os conteúdos que servem como base para a construção de bases teóricas.
 - **Desenvolvimento Técnico**: Contêm os conteúdos que começam a desenvolver bases técnicas.


### PR DESCRIPTION
A abreviação CS seria de Computer Science, mas como é uma versão em português deve ser usado CC.