### PR TITLE
Update the books on Graph Theory

### DIFF
--- a/extras/bibliography/29_graphs.md
+++ b/extras/bibliography/29_graphs.md
@@ -1,25 +1,27 @@
 # Livros: Teoria dos Grafos
 
+> #### ⚠️ Infelizmente, nessa seção a bibliografia está em inglês. Caso conheça materiais de qualidade sobre o assunto em Português, abra um PR.
+
 <hr>
 
-## Grafos: Introdução e Prática
+## Introduction to Graph Theory
 
 <p align="center">
-  <img src="https://github.com/Universidade-Livre/ciencia-da-computacao/assets/30880723/a3d8561e-bdc3-4f6f-beb1-2bd44b0fd091" width="550px">
+  <img src="https://m.media-amazon.com/images/I/41URdh0hZLL._SY425_.jpg" width="550px">
 </p>
 
 <table align="center">
     <tr>
         <th>Título</th>
-        <td>Grafos: Introdução e Prática</td>
+        <td>Introduction to Graph Theory</td>
     </tr>
     <tr>
-        <th>Autores</th>
-        <td>NETTO, P. O. B.; JURKIEWICZ, S. </td>
+        <th>Autor</th>
+        <td>Douglas B. West</td>
     </tr>
     <tr>
         <th>Ano de Publicação</th>
-        <td>2017</td>
+        <td>2000</td>
     </tr>
     <tr>
         <th>Edição</th>
@@ -27,57 +29,102 @@
     </tr>
     <tr>
         <th>ISBN</th>
-        <td>9788521211334</td>
+        <td>9780130144003</td>
     </tr>
 </table>
 
 ### Descrição
 
 <p align="justify">
-A teoria dos grafos é um ramo da Matemática de desenvolvimento relativamente recente, que tem crescido de forma explosiva. Para isso, tem contribuído a sua larga aplicação na modelagem de problemas de distribuição, tráfego e organização de processos, além de outros problemas essenciais, característicos da segunda metade do século XX e do início do século XXI.
-</p>
-
-<p align="justify">
-O livro técnico-científico feito ad-hoc, em todo o mundo, foi sempre a porta de entrada para os cursos universitários de nível de graduação. Com a teoria dos grafos não foi diferente: um grande número de autores preparou seus textos de forma a permitir o uso nesse nível, em muitos casos com a adição de capítulos mais sofisticados que permitiriam ao estudante ir adiante.
-</p>
-
-<p align="justify">
-Esta obra é, também, destinada a alunos de graduação: os autores puderam observar a existência de uma demanda reprimida por um livro que permitisse, exatamente, a introdução e alguma prática com os conceitos da teoria e suas aplicações.
+This book fills a need for a thorough introduction to graph theory that features both the understanding and writing of proofs about graphs. Verification that algorithms work is emphasized more than their complexity. An effective use of examples, and huge number of interesting exercises, demonstrate the topics of trees and distance, matchings and factors, connectivity and paths, graph coloring, edges and cycles, and planar graphs. For those who need to learn to make coherent arguments in the fields of mathematics and computer science.
 </p>
 
 <hr>
 
-## Fundamentos da teoria dos grafos para computação
+## Graph Theory
 
 <p align="center">
-  <img src="https://github.com/Universidade-Livre/ciencia-da-computacao/assets/30880723/4858c332-e3a7-49e7-b713-52cb684b3eb5" width="550px">
+  <img src="https://media.springernature.com/full/springer-static/cover-hires/book/978-3-662-70107-2?as=webp" width="550px">
 </p>
 
 <table align="center">
     <tr>
         <th>Título</th>
-        <td>Fundamentos da teoria dos grafos para computação</td>
+        <td>Graph Theory</td>
     </tr>
     <tr>
-        <th>Autores</th>
-        <td> Maria do Carmo Nicoletti e Estevam R. Hruschka Júnior</td>
+        <th>Autor</th>
+        <td>Reinhard Diestel</td>
     </tr>
     <tr>
         <th>Ano de Publicação</th>
-        <td>2017</td>
+        <td>2025</td>
     </tr>
     <tr>
         <th>Edição</th>
-        <td>3.a edição.</td>
+        <td>6.a edição.</td>
     </tr>
     <tr>
         <th>ISBN</th>
-        <td>9788521634461</td>
+        <td>9783662701065</td>
     </tr>
 </table>
 
 ### Descrição
 
 <p align="justify">
-A Teoria dos Grafos (TG) é um ramo recente na história da Matemática, pois suas origens remontam ao século XVIII. Largamente utilizada na Matemática Aplicada e na Ciência da Computação, a TG tem se mostrado uma importante ferramenta para a modelagem de uma variedade de situações reais em diferentes áreas de conhecimento, tais como as Engenharias, Física, Química, Linguística, Pesquisa Operacional e Inteligência Artificial.Em Fundamentos da Teoria dos Grafos para Computação, os professores Maria do Carmo Nicoletti e Estevam R. Hruschka Jr. apresentam um rico material compilado e refinado ao longo de anos de experiência no Departamento de Computação da Universidade Federal de São Carlos (DC-UFSCar). Originalmente publicada pela editora da universidade, a EdUFSCar, a obra chega à terceira edição, revista e ampliada.O conteúdo deste livro pode ser usado como texto básico para disciplinas introdutórias a TG, como material que promove a revisão da modelagem baseada em grafos a vários problemas, como texto de consulta a vários algoritmos subsidiados por modelagens baseadas em grafos e, particularmente, como um guia na preparação do leitor para disciplinas de pós-graduação que envolvam tópicos mais avançados e complexos associados ao tema.
+This standard textbook on modern graph theory combines the authority of a classic with the engaging freshness of style that is the hallmark of active mathematics. It covers the core material of the subject, with concise yet complete proofs, while offering glimpses of more advanced methods in each field via one or two deeper results.
+</p>
+
+<p align="justify">
+This is a major new edition. Among many other improvements, it offers additional tools for applying the regularity lemma, brings the tangle theory of graph minors up to the cutting edge of current research, and addresses new topics such as chi-boundedness in perfect graph theory.
+</p>
+
+<p align="justify">
+The book can be used as a reliable text for an introductory graduate course and is also suitable for self-study.
+</p>
+
+<hr>
+
+## Graph Theory
+
+<p align="center">
+  <img src="https://media.springernature.com/full/springer-static/cover-hires/book/978-1-84628-969-9?as=webp" width="550px">
+</p>
+
+<table align="center">
+    <tr>
+        <th>Título</th>
+        <td>Graph Theory</td>
+    </tr>
+    <tr>
+        <th>Autores</th>
+        <td>Adrian Bondy e U.S.R. Murty</td>
+    </tr>
+    <tr>
+        <th>Ano de Publicação</th>
+        <td>2008</td>
+    </tr>
+    <tr>
+        <th>Edição</th>
+        <td>1.a edição.</td>
+    </tr>
+    <tr>
+        <th>ISBN</th>
+        <td>9781846289699</td>
+    </tr>
+</table>
+
+### Descrição
+
+<p align="justify">
+Graph theory is a flourishing discipline containing a body of beautiful and powerful theorems of wide applicability. Its explosive growth in recent years is mainly due to its role as an essential structure underpinning modern applied mathematics – computer science, combinatorial optimization, and operations research in particular – but also to its increasing application in the more applied sciences. The versatility of graphs makes them indispensable tools in the design and analysis of communication networks, for instance.
+</p>
+
+<p align="justify">
+The primary aim of this book is to present a coherent introduction to the subject, suitable as a textbook for advanced undergraduate and beginning graduate students in mathematics and computer science. It provides a systematic treatment of the theory of graphs without sacrificing its intuitive and aesthetic appeal. Commonly used proof techniques are described and illustrated, and a wealth of exercises - of varying levels of difficulty - are provided tohelp the reader master the techniques and reinforce their grasp of the material.
+</p>
+
+<p align="justify">
+A second objective is to serve as an introduction to research in graph theory. To this end, sections on more advanced topics are included, and a number of interesting and challenging open problems are highlighted and discussed in some detail. Despite this more advanced material, the book has been organized in such a way that an introductory course on graph theory can be based on the first few sections of selected chapters.
 </p>


### PR DESCRIPTION
A bibliografia foi atualizada para conter os livros popularmente utilizados em Teoria dos Grafos. Estes livros são utilizados internacionalmente e costumam ser a referência padrão.

Embora o material agora encontre-se completamente em inglês, sua qualidade é indiscutível, sendo utilizados na graduação e pós-graduação. Penso que a troca vale a pena.

O [livro do Paulo Netto](https://www.amazon.com.br/Grafos-Paulo-Oswaldo-Boaventura-Netto/dp/8521206801) aparece nas [referências bibliográficas da cadeira na UFC](https://drive.google.com/file/d/0ByomiL4g3q4ALWVJTU1ZYnZfeHc/view?resourcekey=0-8cI-MxyBfOsH-bU3aMiagA). Note que este é diferente do que está disposto no arquivo atualmente. Tomei a decisão de não inserir no PR porque eu não o conheço e nem conheço quem tenha utilizado para falar sobre. Quanto aos três do PR, já utilizei todos.

Os livros em PT-BR então ficam em aberto :)