### PR TITLE
Livro de Teoria da Computação + Mudança na descrição das especializações

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ As disciplinas abaixo não estão divididas por semestre, por serem pouco numero
 
 ## Especializações
 
-Após ter concluído a formação geral, você já deve ter uma ampla visão sobre Ciência da Computação, seus fundamentos e aplicações e estará mais que preparado para escolher uma área de especialidade dentro de suas aplicações para se tornar especialista. A partir daqui não vamos mais elencar pré-requisitos, pois entendemos que com a bagagem da formação geral o aluno já consegue ter pleno conhecimento sobre como estudar temas complexos e decidir como e quando fazer cada curso sem necessitar de recomendação.
+Após ter concluído a formação geral, você já deve ter uma ampla visão sobre Ciência da Computação, seus fundamentos, e suas aplicações. Além disso, você deve estar mais preparado para escolher uma área de especialidade. Abaixo disponibilizamos algumas "carreiras" que o estudante pode escolher para seguir com sua especialização em Ciência da Computação. Sua estrutura deverá ser similar ao disposto na grade principal da UBL. Note que o termo "especialização" não é empregado no mesmo sentido de *pós-graduação lato sensu*, e ao invés disso se refere a uma gama de conteúdos que, se empregados na grade principal, a tornariam menos geral no que diz respeito aos conteúdos base que espera-se de todo cientista da computação. 
 
 Especialização     | Áreas de Atuação
 :--                | :--     

--- a/extras/bibliography/31_theory_of_computation.md
+++ b/extras/bibliography/31_theory_of_computation.md
@@ -1,7 +1,5 @@
 # Livros: Teoria da Computação
 
-> #### ⚠️ Infelizmente, nessa seção a bibliografia está em inglês. Caso conheça materiais de qualidade sobre o assunto em Português, abra um PR.
-
 <hr>
 
 ## Computability, Complexity, and Languages: Fundamentals of Theoretical Computer Science (Computer Science and Scientific Computing)
@@ -34,6 +32,39 @@
 
 <p align="justify">
     Computability, Complexity, and Languages is an introductory text that covers the key areas of computer science, including recursive function theory, formal languages, and automata. It assumes a minimal background in formal mathematics. The book is divided into five parts: Computability, Grammars and Automata, Logic, Complexity, and Unsolvability. Computability theory is introduced in a manner that makes maximum use of previous programming experience, including a "universal" program that takes up less than a page. The number of exercises included has more than tripled. Automata theory, computational logic, and complexity theory are presented in a flexible manner, and can be covered in a variety of different arrangements.
+</p>
+
+<hr>
+
+## Introdução á Teoria da Computação
+
+<p align="center">
+    <img src="https://m.media-amazon.com/images/I/610Mr7w4MlL._SL1005_.jpg" width="550px">
+</p>
+
+<table align="center">
+    <tr>
+        <th>Titulo</th>
+        <td>Introdução á teoria da computação</td>
+    </tr>
+    <tr>
+        <th>Autor</th>
+        <td>Michael Sipser</td>
+    </tr>
+    <tr>
+        <th>Ano de Publicação</th>
+        <td>2005</td>
+    </tr>
+    <tr>
+        <th>Edição</th>
+        <td>2.a edição.</td>
+    </tr>
+</table>
+
+### Descrição
+
+<p align="justify">
+    Esta obra apresenta a teoria da computação por meio de teoremas e provas, sempre com a preocupação do autor em mostrar a intuição por trás de cada resultado e em amenizar a leitura destas últimas, apresentando, para cada teorema, uma ideia da prova. Com este livro, através da prática de resolução de problemas, os alunos, nos exercícios, revisarão definições e conceitos da área e, nos problemas, irão se deparar com atividades que exigem maior engenhosidade. Os três últimos capítulos são novos, e esta 2ª edição incorpora as sugestões de professores e alunos enviadas ao autor ao longo dos anos. Contém material para mais de um semestre de curso, propiciando flexibilidade para escolha de tópicos a serem mais ou menos explorados.
 </p>
 
 <hr>


### PR DESCRIPTION
Adicionei a segunda edição do livro do Sipser, que possui tradução em português, sem remover a terceira edição em inglês.

Aproveitei para também atualizar a descrição das especializações. Em algum momento pretendo adicionar o material de “Design de Algoritmos”, trocando o termo para “Teoria da Computação” ou similar.