### PR TITLE
fix: correct typos across multiple files

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,6 @@
 # Perguntas Frequentes
 
-Esta página tem como objetivo responder perguntas que frequentemente recebemos. Caso a sua dúvida não foi respondida aqui você pode tentar nos enviá-la pelo  [Discord](https://discord.gg/wymGhmf7BT). Caso consideramos importante para muitas pessoas a sua pergunta ou então ela já tenha sido perguntada outras vezes podemos adicionála aqui.
+Esta página tem como objetivo responder perguntas que frequentemente recebemos. Caso a sua dúvida não foi respondida aqui você pode tentar nos enviá-la pelo  [Discord](https://discord.gg/wymGhmf7BT). Caso consideramos importante para muitas pessoas a sua pergunta ou então ela já tenha sido perguntada outras vezes podemos adicioná-la aqui.
 
 ## Sumário
 1. [Haverão mais cursos além de Ciência da Computação?](#haver%C3%A3o-mais-cursos-al%C3%A9m-de-ci%C3%AAncia-da-computa%C3%A7%C3%A3o)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ SOFTWARE.
   </a>
 	
   <a href="https://www.twitch.tv/universidade_livre">
-    <img alt="LinkedIn" width="25" src="https://github.com/Universidade-Livre/imagens/blob/main/png/twitch.png">
+    <img alt="Twitch" width="25" src="https://github.com/Universidade-Livre/imagens/blob/main/png/twitch.png">
   </a>
 </p>
 
@@ -216,7 +216,7 @@ A grade curricular abaixo está dividida em etapas para melhor visualização
 |-------|----------------|----------------|---------------------|
 | 6 | [Linguagens Formais e Autômatos](https://www.youtube.com/watch?v=4zMwOozUt9U&list=PLncEdvQ20-mhD_qMeLHtLnA3XDT1Fr_k4&pp=iAQB) | [Matemática Discreta](https://www.youtube.com/watch?v=KGoSTh1sgyM&list=PL6mfjjCaO1WrEJ0JKRyXO3QjaPkJaSvAS) | [Livros sobre Linguagens Formais e Autômatos](extras/bibliography/26_automata_theory.md) |
 | 6 | [Inteligência Artificial](https://www.youtube.com/watch?v=-T3zDFxngf4&list=PLeejGOroKw_txh7j7S3etF5eudI2WvMx0) | [Estruturas de Dados](https://www.youtube.com/watch?v=0hT3EKGhbpI&list=PLndfcZyvAqbofQl2kLLdeWWjCcPlOPnrW)<br><br>[Probabilidade e Estatística](https://www.youtube.com/watch?v=snXf8YT7L3U&list=PLrOyM49ctTx8HWnxWRBtKrfcuf7ew_3nm) | [Livros sobre Inteligência Artificial](extras/bibliography/27_artificial_intelligence.md) |
-| 6 | [Sistemas Distribuídos](https://www.youtube.com/watch?v=TEEy5f46h_Q&list=PLP0bYj2MTFcuXa4-EbBKhvehr-rkxpeR8&index=1) | [Redes de Computadores](https://www.youtube.com/playlist?list=PLvHXLbw-JSPfKp65psX5C9tyNLHHC4uoR) | [Livros sobre Sistemas Distríbuidos](extras/bibliography/28_distributed_computing.md) |
+| 6 | [Sistemas Distribuídos](https://www.youtube.com/watch?v=TEEy5f46h_Q&list=PLP0bYj2MTFcuXa4-EbBKhvehr-rkxpeR8&index=1) | [Redes de Computadores](https://www.youtube.com/playlist?list=PLvHXLbw-JSPfKp65psX5C9tyNLHHC4uoR) | [Livros sobre Sistemas Distribuídos](extras/bibliography/28_distributed_computing.md) |
 | 6 | [Teoria dos Grafos](https://www.youtube.com/watch?v=kfHqZLYHfHU&list=PLndfcZyvAqbr2MLCOLEvBNX6FgD8UNWfX) | [Matemática Discreta](https://www.youtube.com/watch?v=KGoSTh1sgyM&list=PL6mfjjCaO1WrEJ0JKRyXO3QjaPkJaSvAS) | [Livros sobre Teoria dos Grafos](extras/bibliography/29_graphs.md) |
 | 6 | [Cálculo III](https://www.youtube.com/watch?v=8mBTfk7s63s&list=PLAudUnJeNg4ugGUJo52dtgFZ_tCm1Ds5W) | [Cálculo II](https://www.youtube.com/watch?v=lQdzRBRL9Tw&list=PLAudUnJeNg4sd0TEJ9EG6hr-3d3jqrddN) | [Livros sobre Cálculo III](extras/bibliography/30_multivariable_calculus.md) |
 
@@ -229,7 +229,7 @@ A grade curricular abaixo está dividida em etapas para melhor visualização
 | 7 | [Teoria da Computação](https://www.youtube.com/watch?v=dWRxL30aoes&list=PLYLYA7XrlskNgCeSpJf9PQHHb8Z4WpRm4) | [Linguagens Formais e Autômatos](https://www.youtube.com/watch?v=4zMwOozUt9U&list=PLncEdvQ20-mhD_qMeLHtLnA3XDT1Fr_k4&pp=iAQB) | [Livros sobre Teoria da Computação](extras/bibliography/31_theory_of_computation.md) |
 | 7 | [Deep Learning](https://www.youtube.com/watch?v=0VD_2t6EdS4&list=PL9At2PVRU0ZqVArhU9QMyI3jSe113_m2-) | [Inteligência Artificial](https://www.youtube.com/watch?v=-T3zDFxngf4&list=PLeejGOroKw_txh7j7S3etF5eudI2WvMx0) | [Livros sobre Deep Learning](extras/bibliography/32_deep_learning.md) |
 | 7 | [Compiladores](https://youtube.com/playlist?list=PLX6Nyaq0ebfhI396WlWN6WlBm-tp7vDtV&si=LoaU9lzLMuSVikgi) | [Estruturas de Dados](https://www.youtube.com/watch?v=0hT3EKGhbpI&list=PLndfcZyvAqbofQl2kLLdeWWjCcPlOPnrW)<br><br>[Teoria dos Grafos](https://www.youtube.com/watch?v=kfHqZLYHfHU&list=PLndfcZyvAqbr2MLCOLEvBNX6FgD8UNWfX) | [Livros sobre Compiladores](extras/bibliography/33_compilers.md) |
-| 7 | [Computação Quantica](https://youtube.com/playlist?list=PLUFcRbu9t-v4peHdmDy4rtG3EnbZNS86R&si=hLYHhS2BTKRgNwMJ) | [Cálculo III](https://www.youtube.com/watch?v=8mBTfk7s63s&list=PLAudUnJeNg4ugGUJo52dtgFZ_tCm1Ds5W)<br><br>[Arquitetura de Computadores II](https://www.youtube.com/playlist?list=PLEUHFTHcrJmsqKX-GDD-hBvkF8h2_BfKJ) | [Livros sobre Computação Quântica](extras/bibliography/34_quantum_computing.md) |
+| 7 | [Computação Quântica](https://youtube.com/playlist?list=PLUFcRbu9t-v4peHdmDy4rtG3EnbZNS86R&si=hLYHhS2BTKRgNwMJ) | [Cálculo III](https://www.youtube.com/watch?v=8mBTfk7s63s&list=PLAudUnJeNg4ugGUJo52dtgFZ_tCm1Ds5W)<br><br>[Arquitetura de Computadores II](https://www.youtube.com/playlist?list=PLEUHFTHcrJmsqKX-GDD-hBvkF8h2_BfKJ) | [Livros sobre Computação Quântica](extras/bibliography/34_quantum_computing.md) |
 | 7 | [Metodologia da Pesquisa](https://youtube.com/playlist?list=PLclUQno6PMpQO0-XrDwWsPzRzEvjwp1__&si=0dXojlZV5EisMB6s)  | \- | [Livros sobre Metodologia de Pesquisa](extras/bibliography/35_methodology.md) |
 <!--
 ## Eletivas

--- a/extras/courses.md
+++ b/extras/courses.md
@@ -15,7 +15,7 @@ Curso | Duração | Dedicação
 Curso | Duração | Dedicação
 :-- | :--: | :--:
 [O semestre que falta na sua faculdade em ciência da computação](https://missing-semester-pt.github.io/) | 2 semanas | 12 horas/semana
-[Introdução ao LaTeX](https://www.youtube.com/playlist?list=PLa_2246N48_p9ndUHlO255uvKtSR8mshE) | 1 semanas | 3 horas/semana
+[Introdução ao LaTeX](https://www.youtube.com/playlist?list=PLa_2246N48_p9ndUHlO255uvKtSR8mshE) | 1 semana | 3 horas/semana
 [LaTeX para Iniciantes](https://www.youtube.com/playlist?list=PLF6ZF9NW0Wmq0cgsPVX_mEhB0Kk81qAeF) | 2 semanas | 9 horas/semana
 
 ## Especialização Web

--- a/specializations/computer_graphics.md
+++ b/specializations/computer_graphics.md
@@ -12,7 +12,7 @@ Curso | Duração | Dedicação | Conteúdos
 [Processamento de Imagens](https://www.youtube.com/playlist?list=PLo4jXE-LdDTRaFa39TdNN3FgPAKkcuHvj) | 4 Semanas | 8 horas/semana | Imagem digital; Quantização; Operações com imagens; Dithering; warping de imagens; Aplicações
 [Processamento de Imagens em Python](https://www.youtube.com/playlist?list=PL5TJqBvpXQv54i_HWjd7s70vbP4Is7sK_) | ? Semanas | ? horas/semana | Redimensionamento; Efeitos; Animação; Detecção. 
 [Programação em C++](https://www.youtube.com/playlist?list=PLIUc9-A-aPpqrzY3YuWDUOyQLOBCb5lck) | 3 Semanas | 4 horas/semana | OOP; Smart Pointers; Biblioteca padrão.
-[OpenGL C++ - Gráficos 3D](https://www.youtube.com/playlist?list=PLVRDPs83ZhmcXYuktF3r2hfyoabg_EVPO) | 3 Semanas | 3 horas/semana | OpenGL; C++; Iluminação; Câmera; Modelagem de giguras geométricas; Prática
+[OpenGL C++ - Gráficos 3D](https://www.youtube.com/playlist?list=PLVRDPs83ZhmcXYuktF3r2hfyoabg_EVPO) | 3 Semanas | 3 horas/semana | OpenGL; C++; Iluminação; Câmera; Modelagem de figuras geométricas; Prática
 
 ¹ Áudio em Inglês, mas legendas em Português do Brasil.
 

--- a/specializations/cybersecurity.md
+++ b/specializations/cybersecurity.md
@@ -1,6 +1,6 @@
 ## CyberSecurity
 
-A área da segurança da informação vem crescendo cada vez mais com a ascenção da Internet e dos negócios digitais. Além disso, a LGPD bateu a nossa porta e muitos profissionais precisaram se adaptar e adptar seus softwares. Ou seja, a área de segurança da informação não é voltada somente para usuários finais, mas também para desenvolvedores escrevem códigos mais seguros.
+A área da segurança da informação vem crescendo cada vez mais com a ascensão da Internet e dos negócios digitais. Além disso, a LGPD bateu a nossa porta e muitos profissionais precisaram se adaptar e adaptar seus softwares. Ou seja, a área de segurança da informação não é voltada somente para usuários finais, mas também para desenvolvedores escrevem códigos mais seguros.
 
 Curso | Duração | Dedicação | Conteúdos
 :-- | :--: | :--: | :--:
@@ -19,8 +19,8 @@ Curso | Duração | Dedicação | Conteúdos
 [Criptografia Parte 1](https://www.youtube.com/watch?v=CcU5Kc_FN_4) | 1 semana | 2 horas/semana | Criptografia
 [Criptografia Parte 2](https://www.youtube.com/watch?v=HCHqtpipwu4) | 1 semana | 2 horas/semana | Criptografia
 [Configurar chaves públicas e privadas](https://www.youtube.com/watch?v=7BEsfupYngE) | 1 semana | 2 horas/semana | Chaves de autenticação
-[Curso de Engenharia Reversa Online](https://hackaflag.com.br/academy.html) | 6 semanas | 2 horas/semana | Introduçao Engenharia Reversa
-[Teoría e Ferramentas de Comando e Controle](https://www.youtube.com/watch?v=bUqu8fh7xUg) | 4 dias | 2 horas/dia | Hacking - Ferramentas de Comando e Controle
+[Curso de Engenharia Reversa Online](https://hackaflag.com.br/academy.html) | 6 semanas | 2 horas/semana | Introdução Engenharia Reversa
+[Teoria e Ferramentas de Comando e Controle](https://www.youtube.com/watch?v=bUqu8fh7xUg) | 4 dias | 2 horas/dia | Hacking - Ferramentas de Comando e Controle
 [Curso Python para Pentesters](https://www.youtube.com/watch?v=KsUTiurSGJM&list=PLY-Tw02f5SDIP3CRtcaenRQc8Yz52m6XZ) | 12 semanas | 3 horas/semana | Python; Programação paralela e concorrente; Redes de computadores; Segurança ofensiva
 
 Observações:

--- a/specializations/data_science.md
+++ b/specializations/data_science.md
@@ -12,7 +12,7 @@ Curso | Duração | Dedicação | Conteúdos
 [Análise de Dados em Linguagem R](https://www.escolavirtual.gov.br/curso/325) | 5 semanas | 4 horas / semana | R; RStudio; ML; Análise de Dados.
 [Estatística Descritiva Básica](https://www.youtube.com/playlist?list=PLw9ZE443YE45QSRr576gk6ZfhbWVjiIbr) | 2 horas | 1 semana | Associações; Tipos de Variáveis; Variância e Desvio; Tipos de Gráficos.
 [Essence of Linear Algebra](https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab) ¹ | 2 semanas | 4 horas/semana |  Vetores; Matrizes; Tensores; Espaços; Bases; Transformações.
-[Getting and Cleaning Data](https://www.coursera.org/learn/data-cleaning?specialization=data-science-foundations-r) ¹ | 4 semanas | 8 horas / semana | Manipulaçao de Dados; Limpeza de Dados; Expressões Regulares; APIs.
+[Getting and Cleaning Data](https://www.coursera.org/learn/data-cleaning?specialization=data-science-foundations-r) ¹ | 4 semanas | 8 horas / semana | Manipulação de Dados; Limpeza de Dados; Expressões Regulares; APIs.
 [Exploratory Data Analysis](https://www.coursera.org/learn/exploratory-data-analysis?specialization=data-science-foundations-r) ¹ | 4 semanas | 15 horas / semana | Plotagem de Dados; Sistemas avançados; Padrões de Dados.
 [Reproducible Research](https://www.coursera.org/learn/reproducible-research?specialization=data-science-foundations-r) ¹ | 4 semanas | 2 horas/semana | Organização de Dados; Pesquisa.
 [Estatística computacional](https://www.youtube.com/playlist?list=PLUUx2DlFul6LjL3K9AZT2nTlyZ4o38tE7) | 5 semanas | 4 horas / semana | Razão e Distribuição; Geração de Variáveis; Monte Carlo; Jacknife; AIC e BIC; DIC. 

--- a/specializations/database_administration.md
+++ b/specializations/database_administration.md
@@ -4,7 +4,7 @@
 **Áreas de aplicação**:
 `administração de banco de dados`
 `organização de tabelas de dados`
-`otimização de querys`
+`otimização de queries`
 `segurança de dados`
 `criação de rotinas de bd`
 `big data`

--- a/specializations/web_development.md
+++ b/specializations/web_development.md
@@ -7,7 +7,7 @@ Curso | Duração | Dedicação | Conteúdos
 [HTML e CSS, Parte I](https://www.cursoemvideo.com/curso/html5-css3-modulo1/) | 5 Semanas | 8 horas/semana | Tags; Hierarquias; Semântica.
 [HTML e CSS, Parte II](https://www.cursoemvideo.com/curso/curso-html5-e-css3-modulo-2-de-5-40-horas/) | 5 Semanas | 8 horas/semana | Elementos; IDs; Variáveis.
 [JavaScript Básico](https://www.cursoemvideo.com/curso/javascript/) | 5 Semanas | 8 horas/semana | Sintaxe; DOM; Funções.
-[Curso de JavaScript ES6](https://www.youtube.com/playlist?list=PLWhiA_CuQkbCX9nHuk4rolDYxlLUwXpNI) | 4 Semanas | 2 horas/semana | Módulos; Async/Await; Promisses; Estrutura de Dados.
+[Curso de JavaScript ES6](https://www.youtube.com/playlist?list=PLWhiA_CuQkbCX9nHuk4rolDYxlLUwXpNI) | 4 Semanas | 2 horas/semana | Módulos; Async/Await; Promises; Estrutura de Dados.
 [Debuggando JavaScript](https://www.youtube.com/playlist?list=PLg2lQYZDBwORqALpRkVPXEdgOloQz8sux) | - | 30 minutos | Logs; DEV Tools.
 [Curso de SASS](https://www.youtube.com/watch?v=XwPSWKnZIg4&list=PL97KElaimHeGRtfkksKwxg6IGVZi_cR7J) | 2 Semanas | 2 horas/semana | Preprocessamento CSS; Mixin; Output.
 [Node.js (Express)](https://www.youtube.com/playlist?list=PLJ_KhUnlXUPtbtLwaxxUxHqvcNQndmI4B) | 4 Semanas | 4 horas/semana | Handlebars; Middlewares; Sequelize; MVC.


### PR DESCRIPTION
Corrects spelling and grammar errors found across several files:
- README.md: fixed wrong `alt` text on Twitch link (`LinkedIn` → `Twitch`), `Distríbuidos` → `Distribuídos`, `Quantica` → `Quântica`
- cybersecurity.md: `ascenção` → `ascensão`, `adptar` → `adaptar`, `Introduçao` → `Introdução`, `Teoría` → `Teoria`
- data_science.md: `Manipulaçao` → `Manipulação`
- computer_graphics.md: `giguras` → `figuras`
- database_administration.md: `querys` → `queries`
- FAQ.md: `adicionála` → `adicioná-la`
- web_development.md: `Promisses` → `Promises`
- extras/courses.md: `1 semanas` → `1 semana`