### PR TITLE
fix: corrige link 404 ao clicar no gráfico de dependências do currículo do curso

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Você pode fazer os cursos na ordem, onde, e como preferir. Este é o maior bene
 
 ### Dependências entre assuntos
 
-<a href="https://raw.githubusercontent.com/Universidade-Livre/dependencias-aulas/main/grafo_dependencias_2024.svg"><img src="https://github.com/user-attachments/assets/657953c9-30c3-42b7-87bc-52fc2e6320d7" /></a>
+<a href="https://github.com/user-attachments/assets/657953c9-30c3-42b7-87bc-52fc2e6320d7"><img src="https://github.com/user-attachments/assets/657953c9-30c3-42b7-87bc-52fc2e6320d7" /></a>
 
 (_Clique na imagem para ampliar._)
 


### PR DESCRIPTION
O repo dependencias-aulas não existe mais, o href da subseção **#Dependências entre assuntos**
 apontava para um SVG inexistente causando 404. Esse PR atualiza o link.